### PR TITLE
Fix bare trait object warning

### DIFF
--- a/src/documents.rs
+++ b/src/documents.rs
@@ -340,7 +340,7 @@ where for<'c> BEARER: FirebaseAuthBearer<'c> {
 
 fn get_new_data<'a>(
     url: &str,
-    auth: &'a mut FirebaseAuthBearer<'a>,
+    auth: &'a mut dyn FirebaseAuthBearer<'a>,
 ) -> Result<dto::ListDocumentsResponse> {
     let mut resp = Client::new()
         .get(url)


### PR DESCRIPTION
Thanks for writing this crate! Here's a trivial fix for this warning:

```
   --> src/documents.rs:343:19                                                                                                                                                                
    |                                                                                                                                                                                         
343 |     auth: &'a mut FirebaseAuthBearer<'a>,                                                                                                                                               
    |                   ^^^^^^^^^^^^^^^^^^^^^^ help: use `dyn`: `dyn FirebaseAuthBearer<'a>`                                                                                                  
```