### PR TITLE
Include document name in deserialization errors

### DIFF
--- a/src/firebase_rest_to_rust.rs
+++ b/src/firebase_rest_to_rust.rs
@@ -8,7 +8,7 @@ use serde_json::Value;
 use std::collections::HashMap;
 
 use super::dto;
-use super::errors::Result;
+use super::errors::{FirebaseError, Result};
 
 #[derive(Serialize, Deserialize)]
 struct Wrapper {
@@ -133,7 +133,10 @@ where
     };
 
     let v = serde_json::to_value(r)?;
-    let r: T = serde_json::from_value(v)?;
+    let r: T = serde_json::from_value(v).map_err(|e| FirebaseError::Ser {
+        doc: document.name.to_owned(),
+        ser: e,
+    })?;
     Ok(r)
 }
 


### PR DESCRIPTION
When using documents::list, I got this error:

```
Error: Ser(Error("invalid type: integer `8017`, expected a string", line: 0, column: 0))
```

I suppose there is a mismatch between the data and my DTO struct, but it's inconvenient not to have any information about which specific document to investigate. This is my attempt at improving this situation. Let me know if you think there is a better way, as I am still new to error handling in Rust. With this change I get this more informative error:

```
Error: Ser { doc: Some("projects/<project>/databases/(default)/documents/<collection>/<doc_id>"), ser: Error("invalid type: integer `8017`, expected a string", line: 0, column: 0) }
```
