### PR TITLE
Handle ArrayValues without a values field

### DIFF
--- a/src/dto.rs
+++ b/src/dto.rs
@@ -149,7 +149,7 @@ pub struct UnaryFilter {
 
 #[derive(Default, Clone, Debug, Serialize, Deserialize)]
 pub struct ArrayValue {
-    pub values: Vec<Value>,
+    pub values: Option<Vec<Value>>,
 }
 
 #[derive(Default, Clone, Debug, Serialize, Deserialize)]

--- a/src/firebase_rest_to_rust.rs
+++ b/src/firebase_rest_to_rust.rs
@@ -47,8 +47,10 @@ fn firebase_value_to_serde_value(v: &dto::Value) -> serde_json::Value {
         return Value::Bool(boolean_value);
     } else if let Some(array_value) = v.array_value.as_ref() {
         let mut vec: Vec<Value> = Vec::new();
-        for k in &array_value.values {
-            vec.push(firebase_value_to_serde_value(&k));
+        if let Some(values) = &array_value.values {
+            for k in values {
+                vec.push(firebase_value_to_serde_value(&k));
+            }
         }
         return Value::Array(vec);
     }
@@ -97,7 +99,7 @@ fn serde_value_to_firebase_value(v: &serde_json::Value) -> dto::Value {
             vec.push(serde_value_to_firebase_value(&k));
         }
         return dto::Value {
-            array_value: Some(dto::ArrayValue { values: vec }),
+            array_value: Some(dto::ArrayValue { values: Some(vec) }),
             ..Default::default()
         };
     }


### PR DESCRIPTION
When doing a documents::list, I got a deserialization failure, not on my own structures but on the `dto::ListDocumentsResponse`. Turns out that in `ArrayValue` the `values` field is optional. This one was confusing/fun to debug :smile: 