### PR TITLE
fix: Fix deserialization error when Firestore map is present but empty

### DIFF
--- a/src/dto.rs
+++ b/src/dto.rs
@@ -540,3 +540,28 @@ pub struct WriteRequest {
     #[serde(rename = "streamId")]
     pub stream_id: Option<String>,
 }
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_deserializes_a_document_with_empty_mapvalue() {
+        let doc = r#"{
+        "name": "projects/firestore-db-and-auth/databases/(default)/documents/user/1",
+        "fields": {
+            "gender": {
+                "stringValue": "male"
+            },
+            "age": {
+                "integerValue": "35"
+            },
+            "profile": {
+                "mapValue": {}
+            }
+        },
+        "createTime": "2020-04-28T14:52:51.250511Z",
+        "updateTime": "2020-04-28T14:52:51.250511Z"
+        }"#;
+        let document: Result<crate::dto::Document, serde_json::Error> = serde_json::from_str(&doc);
+        assert!(document.is_ok(), true);
+    }
+}

--- a/src/dto.rs
+++ b/src/dto.rs
@@ -219,7 +219,7 @@ pub struct BatchGetDocumentsRequest {
 
 #[derive(Default, Clone, Debug, Serialize, Deserialize)]
 pub struct MapValue {
-    pub fields: HashMap<String, Value>,
+    pub fields: Option<HashMap<String, Value>>,
 }
 
 #[derive(Default, Clone, Debug, Serialize, Deserialize)]

--- a/src/dto.rs
+++ b/src/dto.rs
@@ -564,4 +564,67 @@ mod tests {
         let document: Result<crate::dto::Document, serde_json::Error> = serde_json::from_str(&doc);
         assert!(document.is_ok(), true);
     }
+
+    #[test]
+    fn it_deserializes_a_document_with_every_data_type() {
+        let doc = r#"{
+        "name": "projects/firestore-db-and-auth/databases/(default)/documents/user/1",
+        "fields": {
+            "exampleArray": {
+                "arrayValue": {
+                    "values": [
+                        {"stringValue": "string-example"},
+                        {"integerValue": "456"}
+                    ]
+                }
+            },
+            "exampleBytes": {
+                "bytesValue": "YWJj"
+            },
+            "exampleBoolean": {
+                "booleanValue": false
+            },
+            "exampleDoubleValue": {
+                "doubleValue": 3.85185988877447170611195588516985463707620329643077639047987759113311767578125
+            },
+            "exampleInteger": {
+                "integerValue": "1024"
+            },
+            "exampleMap": {
+                "mapValue": {
+                    "fields": {
+                        "age": {
+                            "integerValue": "1"
+                        },
+                        "name": {
+                            "stringValue": "Bobby Seale"
+                        }
+                    }
+                }
+            },
+            "exampleNull": {
+                "nullValue": null
+            },
+            "exampleTimestamp": {
+                "timestampValue": "2014-10-02T15:01:23Z"
+            },
+            "exampleString": {
+                "stringValue": "abc-def"
+            },
+            "exampleReferenceValue": {
+                "referenceValue": "projects/firestore-db-and-auth/databases/(default)/documents/test"
+            },
+            "exampleGeoPointValue": {
+                "geoPointValue": {
+                    "latitude": 48.830108,
+                    "longitude": 2.367104
+                }
+            }
+        },
+        "createTime": "2020-04-28T14:52:51.250511Z",
+        "updateTime": "2020-04-28T14:52:51.250511Z"
+        }"#;
+        let document: Result<crate::dto::Document, serde_json::Error> = serde_json::from_str(&doc);
+        assert!(document.is_ok(), true);
+    }
 }

--- a/src/firebase_rest_to_rust.rs
+++ b/src/firebase_rest_to_rust.rs
@@ -37,14 +37,9 @@ pub(crate) fn firebase_value_to_serde_value(v: &dto::Value) -> serde_json::Value
         }
     } else if let Some(map_value) = v.map_value.as_ref() {
         let mut map: Map<String, serde_json::value::Value> = Map::new();
-        match &map_value.fields {
-            Some(map_fields) => {
-                for (map_key, map_v) in map_fields {
-                    map.insert(map_key.clone(), firebase_value_to_serde_value(&map_v));
-                }
-            },
-            None => {
-                // No values to insert into map
+        if let Some(map_fields) = &map_value.fields {
+            for (map_key, map_v) in map_fields {
+                map.insert(map_key.clone(), firebase_value_to_serde_value(&map_v));
             }
         }
         return Value::Object(map);

--- a/src/firebase_rest_to_rust.rs
+++ b/src/firebase_rest_to_rust.rs
@@ -37,8 +37,15 @@ pub(crate) fn firebase_value_to_serde_value(v: &dto::Value) -> serde_json::Value
         }
     } else if let Some(map_value) = v.map_value.as_ref() {
         let mut map: Map<String, serde_json::value::Value> = Map::new();
-        for (map_key, map_v) in &map_value.fields {
-            map.insert(map_key.clone(), firebase_value_to_serde_value(&map_v));
+        match &map_value.fields {
+            Some(map_fields) => {
+                for (map_key, map_v) in map_fields {
+                    map.insert(map_key.clone(), firebase_value_to_serde_value(&map_v));
+                }
+            },
+            None => {
+                // No values to insert into map
+            }
         }
         return Value::Object(map);
     } else if let Some(string_value) = v.string_value.as_ref() {
@@ -80,7 +87,7 @@ pub(crate) fn serde_value_to_firebase_value(v: &serde_json::Value) -> dto::Value
             map.insert(map_key.to_owned(), serde_value_to_firebase_value(&map_v));
         }
         return dto::Value {
-            map_value: Some(dto::MapValue { fields: map }),
+            map_value: Some(dto::MapValue { fields: Some(map) }),
             ..Default::default()
         };
     } else if let Some(string_value) = v.as_str() {
@@ -156,7 +163,7 @@ where
 {
     let v = serde_json::to_value(pod)?;
     Ok(dto::Document {
-        fields: Some(serde_value_to_firebase_value(&v).map_value.unwrap().fields),
+        fields: serde_value_to_firebase_value(&v).map_value.unwrap().fields,
         ..Default::default()
     })
 }


### PR DESCRIPTION
## Summary

Addresses the issue raised in #16. This fixes an issue when a Firestore document contains a map value but has no fields (i.e. `{}`).

## Technical Details

This fixes a deserialization error caused when trying to fulfill the properties defined in `dto::Document`. The fix is relatively simply, this modifies the `dto::MapValue` type to allow for `Option<HashMap<String, Value>>` instead of `HashMap<String,Value>`. In this way we allow for the optional presence of these values.

## Testing

This PR includes unit tests for `dto::Document` to assert that it deserializes correctly when empty `map` is returned.