### PR TITLE
feat(session): create session cookie

### DIFF
--- a/examples/create_read_write_document.rs
+++ b/examples/create_read_write_document.rs
@@ -1,12 +1,9 @@
-use firestore_db_and_auth::{
-    documents, dto, errors, sessions, Credentials, FirebaseAuthBearer, JWKSet, ServiceSession,
-};
+use firestore_db_and_auth::{documents, dto, errors, sessions, Credentials, FirebaseAuthBearer, ServiceSession};
 
 use firestore_db_and_auth::documents::WriteResult;
-use firestore_db_and_auth::jwt::download_google_jwks;
 use serde::{Deserialize, Serialize};
 
-const TEST_USER_ID: &str = include_str!("test_user_id.txt");
+mod utils;
 
 #[derive(Debug, Serialize, Deserialize)]
 struct DemoDTO {
@@ -93,43 +90,16 @@ fn service_account_session(cred: Credentials) -> errors::Result<()> {
     Ok(())
 }
 
-fn user_session_with_cached_refresh_token(cred: &Credentials) -> errors::Result<sessions::user::Session> {
-    println!("Refresh token from file");
-    // Read refresh token from file if possible instead of generating a new refresh token each time
-    let refresh_token: String = match std::fs::read_to_string("refresh-token-for-tests.txt") {
-        Ok(v) => v,
-        Err(e) => {
-            if e.kind() != std::io::ErrorKind::NotFound {
-                return Err(errors::FirebaseError::IO(e));
-            }
-            String::new()
-        }
-    };
-
-    // Generate a new refresh token if necessary
-    println!("Generate new user auth token");
-    let user_session: sessions::user::Session = if refresh_token.is_empty() {
-        let session = sessions::user::Session::by_user_id(&cred, TEST_USER_ID, true)?;
-        std::fs::write("refresh-token-for-tests.txt", &session.refresh_token.as_ref().unwrap())?;
-        session
-    } else {
-        println!("user::Session::by_refresh_token");
-        sessions::user::Session::by_refresh_token(&cred, &refresh_token)?
-    };
-
-    Ok(user_session)
-}
-
 fn user_account_session(cred: Credentials) -> errors::Result<()> {
-    let user_session = user_session_with_cached_refresh_token(&cred)?;
+    let user_session = utils::user_session_with_cached_refresh_token(&cred)?;
 
-    assert_eq!(user_session.user_id, TEST_USER_ID);
+    assert_eq!(user_session.user_id, utils::TEST_USER_ID);
     assert_eq!(user_session.project_id(), cred.project_id);
 
     println!("user::Session::by_access_token");
     let user_session = sessions::user::Session::by_access_token(&cred, &user_session.access_token_unchecked())?;
 
-    assert_eq!(user_session.user_id, TEST_USER_ID);
+    assert_eq!(user_session.user_id, utils::TEST_USER_ID);
 
     let obj = DemoDTO {
         a_string: "abc".to_owned(),
@@ -213,29 +183,6 @@ fn user_account_session(cred: Credentials) -> errors::Result<()> {
     Ok(())
 }
 
-/// Download the two public key JWKS files if necessary and cache the content at the given file path.
-/// Only use this option in cloud functions if the given file path is persistent.
-/// You can use [`Credentials::add_jwks_public_keys`] to manually add more public keys later on.
-pub fn from_cache_file(cache_file: &std::path::Path, c: &Credentials) -> errors::Result<JWKSet> {
-    use std::fs::File;
-    use std::io::BufReader;
-
-    Ok(if cache_file.exists() {
-        let f = BufReader::new(File::open(cache_file)?);
-        let jwks_set: JWKSet = serde_json::from_reader(f)?;
-        jwks_set
-    } else {
-        // If not present, download the two jwks (specific service account + google system account),
-        // merge them into one set of keys and store them in the cache file.
-        let mut jwks = JWKSet::new(&download_google_jwks(&c.client_email)?)?;
-        jwks.keys
-            .append(&mut JWKSet::new(&download_google_jwks("securetoken@system.gserviceaccount.com")?)?.keys);
-        let f = File::create(cache_file)?;
-        serde_json::to_writer_pretty(f, &jwks)?;
-        jwks
-    })
-}
-
 fn main() -> errors::Result<()> {
     // Search for a credentials file in the root directory
     use std::path::PathBuf;
@@ -244,7 +191,7 @@ fn main() -> errors::Result<()> {
     let mut cred = Credentials::from_file(credential_file.to_str().unwrap())?;
 
     // Only download the public keys once, and cache them.
-    let jwkset = from_cache_file(credential_file.with_file_name("cached_jwks.jwks").as_path(), &cred)?;
+    let jwkset = utils::from_cache_file(credential_file.with_file_name("cached_jwks.jwks").as_path(), &cred)?;
     cred.add_jwks_public_keys(&jwkset);
     cred.verify()?;
 
@@ -268,7 +215,7 @@ fn valid_test_credentials() -> errors::Result<Credentials> {
     let mut cred: Credentials = Credentials::new(include_str!("../firebase-service-account.json"))?;
 
     // Only download the public keys once, and cache them.
-    let jwkset = from_cache_file(jwks_path.as_path(), &cred)?;
+    let jwkset = utils::from_cache_file(jwks_path.as_path(), &cred)?;
     cred.add_jwks_public_keys(&jwkset);
     cred.verify()?;
 

--- a/examples/readme.md
+++ b/examples/readme.md
@@ -23,6 +23,17 @@ identified by the firebase user id.
 
 * Build and run with `cargo run --example firebase_user`.
 
+## Session cookie example
+
+This example shows how to exchange a ID token, usually given by the firebase web framework on the client side,
+into a server-side session cookie.
+
+Firebase Auth provides server-side session cookie management for traditional websites that rely on session cookies.
+This solution has several advantages over client-side short-lived ID tokens,
+which may require a redirect mechanism each time to update the session cookie on expiration.
+
+* Build and run with `cargo run --example session_cookie`.
+
 ## Rocket Protected Route example
 
 [Rocket](https://rocket.rs) is a an easy to use web-framework for Rust.

--- a/examples/session_cookie.rs
+++ b/examples/session_cookie.rs
@@ -1,0 +1,41 @@
+use firestore_db_and_auth::{errors::FirebaseError, sessions::session_cookie, Credentials, FirebaseAuthBearer};
+
+use chrono::Duration;
+
+mod utils;
+
+fn main() -> Result<(), FirebaseError> {
+    // Search for a credentials file in the root directory
+    use std::path::PathBuf;
+
+    let mut credential_file = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    credential_file.push("firebase-service-account.json");
+    let mut cred = Credentials::from_file(credential_file.to_str().unwrap())?;
+
+    // Only download the public keys once, and cache them.
+    let jwkset = utils::from_cache_file(credential_file.with_file_name("cached_jwks.jwks").as_path(), &cred)?;
+    cred.add_jwks_public_keys(&jwkset);
+    cred.verify()?;
+
+    let user_session = utils::user_session_with_cached_refresh_token(&cred)?;
+
+    let cookie = session_cookie::create(&cred, user_session.access_token(), Duration::seconds(3600))?;
+    println!("Created session cookie: {}", cookie);
+
+    Ok(())
+}
+
+#[test]
+fn create_session_cookie_test() -> Result<(), FirebaseError> {
+    let cred = utils::valid_test_credentials()?;
+    let user_session = utils::user_session_with_cached_refresh_token(&cred)?;
+
+    assert_eq!(user_session.user_id, utils::TEST_USER_ID);
+    assert_eq!(user_session.project_id(), cred.project_id);
+
+    use chrono::Duration;
+    let cookie = session_cookie::create(&cred, user_session.access_token(), Duration::seconds(3600))?;
+
+    assert!(cookie.len() > 0);
+    Ok(())
+}

--- a/examples/utils/mod.rs
+++ b/examples/utils/mod.rs
@@ -1,0 +1,75 @@
+use firestore_db_and_auth::{errors, sessions, Credentials, JWKSet};
+
+use firestore_db_and_auth::jwt::download_google_jwks;
+
+#[allow(dead_code)]
+pub const TEST_USER_ID: &str = include_str!("../test_user_id.txt");
+
+pub fn user_session_with_cached_refresh_token(cred: &Credentials) -> errors::Result<sessions::user::Session> {
+    println!("Refresh token from file");
+    // Read refresh token from file if possible instead of generating a new refresh token each time
+    let refresh_token: String = match std::fs::read_to_string("refresh-token-for-tests.txt") {
+        Ok(v) => v,
+        Err(e) => {
+            if e.kind() != std::io::ErrorKind::NotFound {
+                return Err(errors::FirebaseError::IO(e));
+            }
+            String::new()
+        }
+    };
+
+    // Generate a new refresh token if necessary
+    println!("Generate new user auth token");
+    let user_session: sessions::user::Session = if refresh_token.is_empty() {
+        let session = sessions::user::Session::by_user_id(&cred, TEST_USER_ID, true)?;
+        std::fs::write("refresh-token-for-tests.txt", &session.refresh_token.as_ref().unwrap())?;
+        session
+    } else {
+        println!("user::Session::by_refresh_token");
+        sessions::user::Session::by_refresh_token(&cred, &refresh_token)?
+    };
+
+    Ok(user_session)
+}
+
+/// Download the two public key JWKS files if necessary and cache the content at the given file path.
+/// Only use this option in cloud functions if the given file path is persistent.
+/// You can use [`Credentials::add_jwks_public_keys`] to manually add more public keys later on.
+pub fn from_cache_file(cache_file: &std::path::Path, c: &Credentials) -> errors::Result<JWKSet> {
+    use std::fs::File;
+    use std::io::BufReader;
+
+    Ok(if cache_file.exists() {
+        let f = BufReader::new(File::open(cache_file)?);
+        let jwks_set: JWKSet = serde_json::from_reader(f)?;
+        jwks_set
+    } else {
+        // If not present, download the two jwks (specific service account + google system account),
+        // merge them into one set of keys and store them in the cache file.
+        let mut jwks = JWKSet::new(&download_google_jwks(&c.client_email)?)?;
+        jwks.keys
+            .append(&mut JWKSet::new(&download_google_jwks("securetoken@system.gserviceaccount.com")?)?.keys);
+        let f = File::create(cache_file)?;
+        serde_json::to_writer_pretty(f, &jwks)?;
+        jwks
+    })
+}
+
+/// For integration tests and doc code snippets: Create a Credentials instance.
+/// Necessary public jwk sets are downloaded or re-used if already present.
+#[cfg(test)]
+#[allow(dead_code)]
+pub fn valid_test_credentials() -> errors::Result<Credentials> {
+    use std::path::PathBuf;
+    let mut jwks_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    jwks_path.push("firebase-service-account.jwks");
+
+    let mut cred: Credentials = Credentials::new(include_str!("../../firebase-service-account.json"))?;
+
+    // Only download the public keys once, and cache them.
+    let jwkset = from_cache_file(jwks_path.as_path(), &cred)?;
+    cred.add_jwks_public_keys(&jwkset);
+    cred.verify()?;
+
+    Ok(cred)
+}

--- a/src/dto.rs
+++ b/src/dto.rs
@@ -1,3 +1,9 @@
+//! # Data Transfer Object definitions
+//! In this module only those Data Transfer Objects (DTO) are defined, which are used by the firebase API
+//! to access, alter documents or firebase users.
+//!
+//! Domain specific DTOs for OAuth or session management are defined in [`crate::session`].
+
 use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};


### PR DESCRIPTION
This is the continuation of #13 

 Firebase Auth provides server-side session cookie management for traditional websites that rely on session cookies.
 This solution has several advantages over client-side short-lived ID tokens,
 which may require a redirect mechanism each time to update the session cookie on expiration:

 * Improved security via JWT-based session tokens that can only be generated using authorized service accounts.
 * Stateless session cookies that come with all the benefit of using JWTs for authentication.
   The session cookie has the same claims (including custom claims) as the ID token, making the same permissions checks enforceable on the session cookies.
 * Ability to create session cookies with custom expiration times ranging from 5 minutes to 2 weeks.
 * Flexibility to enforce cookie policies based on application requirements: domain, path, secure, httpOnly, etc.
 * Ability to revoke session cookies when token theft is suspected using the existing refresh token revocation API.
 * Ability to detect session revocation on major account changes.

 See https://firebase.google.com/docs/auth/admin/manage-cookies

---

Add free standing function sessions::create_session_cookie(credentials, id_token, duration)

Fixes #14