### PR TITLE
Added user session by OAuth2 Federated provider

### DIFF
--- a/src/dto.rs
+++ b/src/dto.rs
@@ -547,6 +547,34 @@ pub struct WriteRequest {
     pub stream_id: Option<String>,
 }
 
+#[derive(Serialize, Debug)]
+pub struct SignInWithIdpRequest {
+    pub post_body: String,
+    pub request_uri: String,
+    pub return_idp_credential: bool,
+    pub return_secure_token: bool,
+}
+
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OAuthResponse {
+    pub federated_id: String,
+    pub provider_id: String,
+    pub local_id: String,
+    pub email_verified: bool,
+    pub email: String,
+    pub oauth_access_token: String,
+    pub first_name: String,
+    pub last_name: String,
+    pub full_name: String,
+    pub display_name: String,
+    pub id_token: String,
+    pub photo_url: String,
+    pub refresh_token: String,
+    pub expires_in: String,
+    pub raw_user_info: String,
+}
+
 #[cfg(test)]
 mod tests {
     #[test]


### PR DESCRIPTION
I have added user session by OAuth2 Federated provider.
List of default providers are at:
https://firebase.google.com/docs/projects/provisioning/configure-oauth?hl=en#add-idp
Code is implementing this endpoint:
https://firebase.google.com/docs/reference/rest/auth?hl=en#section-sign-in-with-oauth-credential

it's better version of my code that I have written for my university project, where I only used it for Google and Facebook OAuth2:
https://github.com/MacKarp/Cookbook/tree/main/Desktop/firebase_handler/src

`access_token` from provider - eg.: https://docs.rs/oauth2/4.0.0/oauth2/#example-3
`provider` from enum `OAuth2Provider`
`request_uri` should be same as your request_uri/redirect_uri for OAuth provider request
`with_refresh_token` - needed by `Session::by_user_id()`

after getting response from firebase it creates user session with existing `Session::by_user_id()`