### PR TITLE
Fixes #28 allow session_cookie::create duration greater than sixty minutes.

### DIFF
--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -353,7 +353,7 @@ pub mod session_cookie {
         duration: chrono::Duration,
     ) -> Result<String, FirebaseError> {
         // Generate the assertion from the admin credentials
-        let assertion = crate::jwt::session_cookie::create_jwt_encoded(credentials, duration)?;
+        let assertion = crate::jwt::session_cookie::create_jwt_encoded(credentials, chrono::Duration::minutes(1))?;
 
         // Request Google Oauth2 to retrieve the access token in order to create a session cookie
         let client = reqwest::blocking::Client::new();


### PR DESCRIPTION
Fixes https://github.com/davidgraeff/firestore-db-and-auth-rs/issues/28, allow cookie greater than sixty minutes.