### PR TITLE
feat(wasm): added wasm support, moved blocking to a feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ features = ["external_doc", "rocket_support"]
 
 [features]
 default = ["rustls-tls", "unstable"]
+blocking = []
 rocket_support = ["rocket"]
 rustls-tls = ["reqwest/rustls-tls"]
 default-tls = ["reqwest/default-tls"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.64"
 [dependencies]
 bytes = "1.1"
 cache_control = "0.2"
-reqwest = { version = "0.12.7", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.11.16", default-features = false, features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 chrono = { version = "0.4", features = ["serde"] }
@@ -42,7 +42,7 @@ features = ["external_doc", "rocket_support"]
 
 [features]
 default = ["rustls-tls", "unstable"]
-blocking = []
+blocking = ["reqwest/blocking"]
 rocket_support = ["rocket"]
 rustls-tls = ["reqwest/rustls-tls"]
 default-tls = ["reqwest/default-tls"]
@@ -50,6 +50,7 @@ native-tls = ["reqwest/native-tls"]
 native-tls-vendored = ["reqwest/native-tls-vendored"]
 unstable = []
 external_doc = []
+wasm32 = ["ring/wasm32_unknown_unknown_js", "ring/std", "tokio/rt", "tokio/sync"]
 
 [[example]]
 name = "create_read_write_document"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "firestore-db-and-auth"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["David Gräff <david.graeff@web.de>"]
 edition = "2021"
 license = "MIT"
 description = "This crate allows easy access to your Google Firestore DB via service account or OAuth impersonated Google Firebase Auth credentials."
 readme = "readme.md"
 keywords = ["firestore", "auth"]
-categories = ["api-bindings","authentication"]
+categories = ["api-bindings", "authentication"]
 maintenance = { status = "passively-maintained" }
 repository = "https://github.com/davidgraeff/firestore-db-and-auth-rs"
 rust-version = "1.64"
@@ -15,7 +15,7 @@ rust-version = "1.64"
 [dependencies]
 bytes = "1.1"
 cache_control = "0.2"
-reqwest = { version = "0.11", default-features = false, features = ["json", "blocking", "hyper-rustls"] }
+reqwest = { version = "0.12.7", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 chrono = { version = "0.4", features = ["serde"] }
@@ -38,7 +38,7 @@ optional = true
 
 # Render the readme file on doc.rs
 [package.metadata.docs.rs]
-features = [ "external_doc", "rocket_support" ]
+features = ["external_doc", "rocket_support"]
 
 [features]
 default = ["rustls-tls", "unstable"]
@@ -65,4 +65,4 @@ test = true
 [[example]]
 name = "rocket_http_protected_route"
 test = true
-required-features = ["rustls-tls","rocket_support"]
+required-features = ["rustls-tls", "rocket_support"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ optional = true
 features = ["external_doc", "rocket_support"]
 
 [features]
-default = ["rustls-tls", "unstable"]
+default = ["rustls-tls", "unstable", "blocking"]
 blocking = ["reqwest/blocking"]
 rocket_support = ["rocket"]
 rustls-tls = ["reqwest/rustls-tls"]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -169,9 +169,9 @@ struct GoogleRESTApiErrorWrapper {
 /// - response: The http requests response. Must be mutable, because the contained value will be extracted in an error case
 /// - context: A function that will be called in an error case that returns a context string
 pub(crate) fn extract_google_api_error(
-    response: reqwest::blocking::Response,
+    response: reqwest::Response,
     context: impl Fn() -> String,
-) -> Result<reqwest::blocking::Response> {
+) -> Result<reqwest::Response> {
     if response.status() == 200 {
         return Ok(response);
     }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -6,6 +6,7 @@ use std::fmt;
 use reqwest;
 use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
+use crate::http2;
 
 /// A result type that uses [`FirebaseError`] as an error type
 pub type Result<T> = std::result::Result<T, FirebaseError>;
@@ -169,9 +170,9 @@ struct GoogleRESTApiErrorWrapper {
 /// - response: The http requests response. Must be mutable, because the contained value will be extracted in an error case
 /// - context: A function that will be called in an error case that returns a context string
 pub(crate) fn extract_google_api_error(
-    response: reqwest::Response,
+    response: http2::Response,
     context: impl Fn() -> String,
-) -> Result<reqwest::Response> {
+) -> Result<http2::Response> {
     if response.status() == 200 {
         return Ok(response);
     }

--- a/src/http2.rs
+++ b/src/http2.rs
@@ -1,0 +1,11 @@
+#[cfg(feature = "blocking")]
+pub type Response = reqwest::blocking::Response;
+
+#[cfg(not(feature = "blocking"))]
+pub type Response = reqwest::Response;
+
+#[cfg(feature = "blocking")]
+pub type Client = reqwest::blocking::Client;
+
+#[cfg(not(feature = "blocking"))]
+pub type Client = reqwest::Client;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ pub mod users;
 pub mod rocket;
 mod http2;
 
+use async_trait::async_trait;
 // Forward declarations
 pub use credentials::Credentials;
 pub use jwt::JWKSet;
@@ -27,7 +28,8 @@ pub use sessions::user::Session as UserSession;
 /// Firestore document methods in [`crate::documents`] expect an object that implements this `FirebaseAuthBearer` trait.
 ///
 /// Implement this trait for your own data structure and provide the Firestore project id and a valid access token.
-#[async_trait::async_trait]
+#[cfg_attr(target_family = "wasm", async_trait(?Send))]
+#[cfg_attr(not(target_family = "wasm"), async_trait)]
 pub trait FirebaseAuthBearer {
     /// Return the project ID. This is required for the firebase REST API.
     fn project_id(&self) -> &str;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod users;
 
 #[cfg(feature = "rocket_support")]
 pub mod rocket;
+mod http2;
 
 // Forward declarations
 pub use credentials::Credentials;

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -430,7 +430,7 @@ pub mod session_cookie {
         let assertion = crate::jwt::session_cookie::create_jwt_encoded(credentials, duration).await?;
 
         // Request Google Oauth2 to retrieve the access token in order to create a session cookie
-        let client = reqwest::blocking::Client::new();
+        let client = reqwest::Client::new();
         let response_oauth2: Oauth2ResponseDTO = client
             .post(GOOGLE_OAUTH2_URL)
             .form(&[

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -361,6 +361,7 @@ pub mod user {
 }
 
 pub mod session_cookie {
+    use crate::http2;
     use super::*;
 
     pub static GOOGLE_OAUTH2_URL: &str = "https://accounts.google.com/o/oauth2/token";
@@ -430,7 +431,7 @@ pub mod session_cookie {
         let assertion = crate::jwt::session_cookie::create_jwt_encoded(credentials, duration).await?;
 
         // Request Google Oauth2 to retrieve the access token in order to create a session cookie
-        let client = reqwest::Client::new();
+        let client = http2::Client::new();
         let response_oauth2: Oauth2ResponseDTO = client
             .post(GOOGLE_OAUTH2_URL)
             .form(&[


### PR DESCRIPTION
Hi everybody,
I added support for wasm(32) to this library by adding the `wasm32` feature, which fixes the dependencies for wasm, and by disabling Send + Sync on `async_traits` when compiling for wasm.

Since wasm environments are inherently single-threaded this is safe.

I also moved blocking behaviour behind a feature flag, since it needs to be disabled for wasm. However I included it in the default features to ensure compatibility.